### PR TITLE
Add loading states for file operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ function App() {
     filePath,
     content,
     setContent,
+    isLoading,
     openFile,
     saveFile,
     saveFileAs,
@@ -80,6 +81,11 @@ function App() {
 
   return (
     <div className="app-container">
+      {isLoading && (
+        <div className="loading-overlay" role="status" aria-label="Loading">
+          <div className="loading-spinner" />
+        </div>
+      )}
       <Toolbar
         filePath={filePath}
         content={content}

--- a/src/hooks/useFileOperations.ts
+++ b/src/hooks/useFileOperations.ts
@@ -6,10 +6,12 @@ export function useFileOperations() {
   const [filePath, setFilePath] = useState<string | null>(null);
   const [content, setContent] = useState("");
   const [savedContent, setSavedContent] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
   const isDirty = content !== savedContent;
 
   const loadFileFromPath = useCallback(async (path: string) => {
+    setIsLoading(true);
     try {
       const text = await readTextFile(path);
       setContent(text);
@@ -17,6 +19,8 @@ export function useFileOperations() {
       setFilePath(path);
     } catch (err) {
       console.error("Failed to read file:", path, err);
+    } finally {
+      setIsLoading(false);
     }
   }, []);
 
@@ -35,6 +39,7 @@ export function useFileOperations() {
   }, [loadFileFromPath]);
 
   const saveFile = useCallback(async () => {
+    setIsLoading(true);
     try {
       if (filePath) {
         await writeTextFile(filePath, content);
@@ -51,10 +56,13 @@ export function useFileOperations() {
       }
     } catch (err) {
       console.error("Failed to save file:", err);
+    } finally {
+      setIsLoading(false);
     }
   }, [filePath, content]);
 
   const saveFileAs = useCallback(async () => {
+    setIsLoading(true);
     try {
       const path = await save({
         filters: [{ name: "Markdown", extensions: ["md", "markdown"] }],
@@ -66,6 +74,8 @@ export function useFileOperations() {
       }
     } catch (err) {
       console.error("Failed to save file:", err);
+    } finally {
+      setIsLoading(false);
     }
   }, [content]);
 
@@ -74,6 +84,7 @@ export function useFileOperations() {
     content,
     savedContent,
     isDirty,
+    isLoading,
     setContent,
     openFile,
     saveFile,

--- a/src/theme.css
+++ b/src/theme.css
@@ -400,3 +400,33 @@ html, body, #root {
 .preview-pane::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
 }
+
+/* ========== Loading Overlay ========== */
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--text-primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `isLoading` state to `useFileOperations` hook, toggled via `try/finally` around all file read/write operations (`loadFileFromPath`, `saveFile`, `saveFileAs`)
- Renders a translucent overlay with a CSS spinner in `App.tsx` when `isLoading` is true, giving users visual feedback during file I/O
- Loading overlay uses `pointer-events: none` so it doesn't block interaction, and respects theme variables for consistent styling

## Test plan
- [ ] Open a large markdown file — spinner should briefly appear
- [ ] Save a file — spinner should briefly appear during write
- [ ] Save As to a new path — spinner should appear during write
- [ ] Verify spinner disappears even if an operation fails (error path)
- [ ] Check overlay appearance in both light and dark themes

Closes #21