### PR TITLE
feat: preview-only default with Edit toggle button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Toolbar from "./components/Toolbar";
 import EditorPane from "./components/EditorPane";
 import PreviewPane from "./components/PreviewPane";
@@ -25,7 +25,24 @@ function App() {
 
   const { zoomIn, zoomOut, resetZoom } = useFontSize();
   const { mode, isDark, cycleTheme } = useTheme();
-  const { split, containerRef, onMouseDown } = useSplitPane();
+  const { split, resetSplit, containerRef, onMouseDown } = useSplitPane();
+
+  // Editor starts visible (no file) or hidden (file loaded)
+  const [editorVisible, setEditorVisible] = useState(true);
+
+  const toggleEditor = useCallback(() => {
+    setEditorVisible((prev) => {
+      if (!prev) resetSplit();
+      return !prev;
+    });
+  }, [resetSplit]);
+
+  // When a file is loaded, hide the editor (preview-only mode)
+  useEffect(() => {
+    if (filePath) {
+      setEditorVisible(false);
+    }
+  }, [filePath]);
 
   useKeyboardShortcuts({
     onOpen: openFile,
@@ -34,6 +51,7 @@ function App() {
     onZoomIn: zoomIn,
     onZoomOut: zoomOut,
     onResetZoom: resetZoom,
+    onToggleEditor: toggleEditor,
   });
 
   // On mount, check if a file was passed via Finder before the frontend was ready
@@ -43,7 +61,7 @@ function App() {
       .then(({ invoke }) =>
         invoke<string | null>("get_initial_file").then((path) => {
           if (path && isValidMarkdownPath(path)) loadFileFromPath(path);
-        })
+        }),
       )
       .catch((err) => console.error("Failed to get initial file:", err));
   }, [loadFileFromPath]);
@@ -60,7 +78,7 @@ function App() {
           }
         }).then((fn) => {
           unlisten = fn;
-        })
+        }),
       )
       .catch((err) => console.error("Failed to listen for file-opened:", err));
     return () => {
@@ -90,14 +108,20 @@ function App() {
         filePath={filePath}
         content={content}
         themeMode={mode}
+        editorVisible={editorVisible}
         onCycleTheme={cycleTheme}
+        onToggleEditor={toggleEditor}
       />
       <div className="main-content" ref={containerRef}>
-        <div style={{ width: `${split}%`, height: "100%", overflow: "hidden" }}>
-          <EditorPane content={content} onChange={setContent} isDark={isDark} />
-        </div>
-        <div className="split-divider" onMouseDown={onMouseDown} />
-        <div style={{ width: `${100 - split}%`, height: "100%" }}>
+        {editorVisible && (
+          <>
+            <div style={{ width: `${split}%`, height: "100%", overflow: "hidden" }}>
+              <EditorPane content={content} onChange={setContent} isDark={isDark} />
+            </div>
+            <div className="split-divider" onMouseDown={onMouseDown} />
+          </>
+        )}
+        <div style={{ width: editorVisible ? `${100 - split}%` : "100%", height: "100%" }}>
           <PreviewPane content={content} />
         </div>
       </div>

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -34,10 +34,9 @@ const baseTheme = EditorView.theme({
   ".cm-activeLineGutter": {
     backgroundColor: "transparent",
   },
-  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection":
-    {
-      backgroundColor: "rgba(128, 128, 128, 0.2) !important",
-    },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground, ::selection": {
+    backgroundColor: "rgba(128, 128, 128, 0.2) !important",
+  },
 });
 
 // Light mode syntax colors
@@ -94,12 +93,7 @@ const darkHighlighting = HighlightStyle.define([
 
 function buildExtensions(isDark: boolean): Extension[] {
   const highlighting = isDark ? darkHighlighting : lightHighlighting;
-  return [
-    markdown(),
-    baseTheme,
-    EditorView.lineWrapping,
-    syntaxHighlighting(highlighting),
-  ];
+  return [markdown(), baseTheme, EditorView.lineWrapping, syntaxHighlighting(highlighting)];
 }
 
 export default function EditorPane({ content, onChange, isDark }: EditorPaneProps) {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,7 +5,9 @@ interface ToolbarProps {
   filePath: string | null;
   content: string;
   themeMode: ThemeMode;
+  editorVisible: boolean;
   onCycleTheme: () => void;
+  onToggleEditor: () => void;
 }
 
 // SVG icons for each theme mode
@@ -44,13 +46,29 @@ function ThemeIcon({ mode }: { mode: ThemeMode }) {
   );
 }
 
+function EditIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3">
+      <path d="M11.5 1.5l3 3-9 9H2.5v-3l9-9z" />
+      <line x1="9" y1="4" x2="12" y2="7" />
+    </svg>
+  );
+}
+
 const modeLabels: Record<ThemeMode, string> = {
   system: "System",
   light: "Light",
   dark: "Dark",
 };
 
-export default function Toolbar({ filePath, content, themeMode, onCycleTheme }: ToolbarProps) {
+export default function Toolbar({
+  filePath,
+  content,
+  themeMode,
+  editorVisible,
+  onCycleTheme,
+  onToggleEditor,
+}: ToolbarProps) {
   const [copied, setCopied] = useState(false);
 
   const filename = filePath ? filePath.replace(/\\/g, "/").split("/").pop() : null;
@@ -67,7 +85,17 @@ export default function Toolbar({ filePath, content, themeMode, onCycleTheme }: 
 
   return (
     <div className="toolbar" data-tauri-drag-region>
-      <div className="toolbar-spacer" />
+      <div className="toolbar-left">
+        <button
+          className={`toolbar-btn toolbar-edit-btn${editorVisible ? " active" : ""}`}
+          onClick={onToggleEditor}
+          title="Toggle editor (⌘E)"
+        >
+          <EditIcon />
+          Edit
+          <kbd className="toolbar-kbd">⌘E</kbd>
+        </button>
+      </div>
       <span className="toolbar-filename">{filename || "Untitled"}</span>
       <div className="toolbar-spacer" />
       <div className="toolbar-actions">

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ interface ShortcutActions {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onResetZoom: () => void;
+  onToggleEditor: () => void;
 }
 
 export function useKeyboardShortcuts({
@@ -16,6 +17,7 @@ export function useKeyboardShortcuts({
   onZoomIn,
   onZoomOut,
   onResetZoom,
+  onToggleEditor,
 }: ShortcutActions) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -28,6 +30,9 @@ export function useKeyboardShortcuts({
       } else if (e.metaKey && e.key === "s") {
         e.preventDefault();
         onSave();
+      } else if (e.metaKey && e.key === "e") {
+        e.preventDefault();
+        onToggleEditor();
       } else if (e.metaKey && (e.key === "=" || e.key === "+")) {
         e.preventDefault();
         onZoomIn();
@@ -42,5 +47,5 @@ export function useKeyboardShortcuts({
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onOpen, onSave, onSaveAs, onZoomIn, onZoomOut, onResetZoom]);
+  }, [onOpen, onSave, onSaveAs, onZoomIn, onZoomOut, onResetZoom, onToggleEditor]);
 }

--- a/src/hooks/useSplitPane.ts
+++ b/src/hooks/useSplitPane.ts
@@ -1,20 +1,12 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { clamp } from "../utils/clamp";
 
-const STORAGE_KEY = "dotmd-split";
 const DEFAULT_SPLIT = 50;
 const MIN_SPLIT = 20;
 const MAX_SPLIT = 80;
 
 export function useSplitPane() {
-  const [split, setSplit] = useState<number>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const val = parseFloat(stored);
-      if (!isNaN(val)) return clamp(val, MIN_SPLIT, MAX_SPLIT);
-    }
-    return DEFAULT_SPLIT;
-  });
+  const [split, setSplit] = useState<number>(DEFAULT_SPLIT);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
@@ -24,6 +16,10 @@ export function useSplitPane() {
     onMouseMove: ((ev: MouseEvent) => void) | null;
     onMouseUp: (() => void) | null;
   }>({ onMouseMove: null, onMouseUp: null });
+
+  const resetSplit = useCallback(() => {
+    setSplit(DEFAULT_SPLIT);
+  }, []);
 
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -38,10 +34,6 @@ export function useSplitPane() {
 
     const onMouseUp = () => {
       dragging.current = false;
-      setSplit((current) => {
-        localStorage.setItem(STORAGE_KEY, String(current));
-        return current;
-      });
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
       document.body.style.cursor = "";
@@ -67,5 +59,5 @@ export function useSplitPane() {
     };
   }, []);
 
-  return { split, containerRef, onMouseDown };
+  return { split, resetSplit, containerRef, onMouseDown };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,5 +6,5 @@ import "./theme.css";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/theme.css
+++ b/src/theme.css
@@ -39,34 +39,34 @@
 }
 
 html[data-theme="dark"] {
-    --bg-primary: #232323;
-    --bg-editor: #232323;
-    --bg-preview: #2b2b2b;
-    --bg-toolbar: #333;
-    --bg-divider: #444;
-    --text-primary: #d4d4d4;
-    --text-secondary: #aaa;
-    --text-muted: #777;
-    --border-color: #444;
+  --bg-primary: #232323;
+  --bg-editor: #232323;
+  --bg-preview: #2b2b2b;
+  --bg-toolbar: #333;
+  --bg-divider: #444;
+  --text-primary: #d4d4d4;
+  --text-secondary: #aaa;
+  --text-muted: #777;
+  --border-color: #444;
 
-    --code-block-bg: #3a3a3a;
-    --code-block-text: #d4d4d4;
-    --inline-code-bg: #3d3528;
-    --inline-code-text: #e0c9a6;
+  --code-block-bg: #3a3a3a;
+  --code-block-text: #d4d4d4;
+  --inline-code-bg: #3d3528;
+  --inline-code-text: #e0c9a6;
 
-    --link-color: #7bb8d0;
-    --blockquote-border: #b8956a;
-    --blockquote-bg: rgba(184, 149, 106, 0.1);
+  --link-color: #7bb8d0;
+  --blockquote-border: #b8956a;
+  --blockquote-bg: rgba(184, 149, 106, 0.1);
 
-    --table-header-bg: #383838;
-    --table-border: #4a4a4a;
-    --table-stripe-bg: #303030;
+  --table-header-bg: #383838;
+  --table-border: #4a4a4a;
+  --table-stripe-bg: #303030;
 
-    --checkbox-checked: #7cb88a;
-    --checkbox-border: #666;
+  --checkbox-checked: #7cb88a;
+  --checkbox-border: #666;
 
-    --copy-btn-bg: #444;
-    --copy-btn-hover: #555;
+  --copy-btn-bg: #444;
+  --copy-btn-hover: #555;
 }
 
 /* ========== Reset & Base ========== */
@@ -76,7 +76,9 @@ html[data-theme="dark"] {
   box-sizing: border-box;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
@@ -122,6 +124,12 @@ html, body, #root {
   pointer-events: none;
 }
 
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  -webkit-app-region: no-drag;
+}
+
 .toolbar-spacer {
   flex: 1;
 }
@@ -137,15 +145,16 @@ html, body, #root {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 12px;
+  padding: 6px 14px;
   border: none;
   border-radius: 6px;
   background: var(--copy-btn-bg);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition: background 0.15s;
+  height: 32px;
 }
 
 .toolbar-btn:hover {
@@ -153,16 +162,37 @@ html, body, #root {
 }
 
 .toolbar-btn svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
+}
+
+.toolbar-edit-btn.active {
+  background: var(--link-color);
+  color: #fff;
+}
+
+.toolbar-edit-btn.active:hover {
+  opacity: 0.9;
+}
+
+.toolbar-kbd {
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+
+.toolbar-edit-btn.active .toolbar-kbd {
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .toolbar-menu-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -228,8 +258,12 @@ html, body, #root {
   padding: 32px 40px;
 }
 
-.preview-pane h1, .preview-pane h2, .preview-pane h3,
-.preview-pane h4, .preview-pane h5, .preview-pane h6 {
+.preview-pane h1,
+.preview-pane h2,
+.preview-pane h3,
+.preview-pane h4,
+.preview-pane h5,
+.preview-pane h6 {
   font-family: var(--font-serif);
   color: var(--text-primary);
   margin-top: 1.4em;
@@ -249,8 +283,12 @@ html, body, #root {
   padding-bottom: 0.25em;
 }
 
-.preview-pane h3 { font-size: 1.25em; }
-.preview-pane h4 { font-size: 1.1em; }
+.preview-pane h3 {
+  font-size: 1.25em;
+}
+.preview-pane h4 {
+  font-size: 1.1em;
+}
 
 .preview-pane p {
   font-family: var(--font-serif);
@@ -312,7 +350,8 @@ html, body, #root {
 }
 
 /* Lists */
-.preview-pane ul, .preview-pane ol {
+.preview-pane ul,
+.preview-pane ol {
   font-family: var(--font-serif);
   font-size: var(--preview-font-size);
   line-height: 1.75;


### PR DESCRIPTION
## Summary

Closes #28

- Existing .md files now open in preview-only mode (full-width preview, editor hidden)
- New Edit toggle button (⌘E) on the left side of the toolbar shows/hides the editor at 50/50 split
- Split position resets to 50% each toggle and no longer persists to localStorage
- Unsaved edits are preserved in memory when editor is toggled off
- All toolbar buttons resized to be consistently larger for easy clicking