### PR TITLE
Add double-click divider reset to 50/50

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
 
   const { zoomIn, zoomOut, resetZoom } = useFontSize();
   const { mode, isDark, cycleTheme } = useTheme();
-  const { split, resetSplit, containerRef, onMouseDown } = useSplitPane();
+  const { split, resetSplit, containerRef, onMouseDown, onDividerDoubleClick } = useSplitPane();
 
   // Editor starts visible (no file) or hidden (file loaded)
   const [editorVisible, setEditorVisible] = useState(true);
@@ -145,7 +145,11 @@ function App() {
             <div style={{ width: `${split}%`, height: "100%", overflow: "hidden" }}>
               <EditorPane content={content} onChange={setContent} isDark={isDark} />
             </div>
-            <div className="split-divider" onMouseDown={onMouseDown} />
+            <div
+              className="split-divider"
+              onMouseDown={onMouseDown}
+              onDoubleClick={onDividerDoubleClick}
+            />
           </>
         )}
         <div style={{ width: editorVisible ? `${100 - split}%` : "100%", height: "100%" }}>

--- a/src/hooks/useSplitPane.ts
+++ b/src/hooks/useSplitPane.ts
@@ -21,6 +21,10 @@ export function useSplitPane() {
     setSplit(DEFAULT_SPLIT);
   }, []);
 
+  const onDividerDoubleClick = useCallback(() => {
+    resetSplit();
+  }, [resetSplit]);
+
   const onMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     dragging.current = true;
@@ -59,5 +63,5 @@ export function useSplitPane() {
     };
   }, []);
 
-  return { split, resetSplit, containerRef, onMouseDown };
+  return { split, resetSplit, containerRef, onMouseDown, onDividerDoubleClick };
 }


### PR DESCRIPTION
## Summary

- Adds `onDoubleClick` handler to the split divider that resets editor/preview split to the 50% default
- Single-click + drag behavior is unchanged — double-click is a separate event that doesn't interfere

Closes #29

## Test plan

- [ ] Double-click the divider → split resets to 50/50
- [ ] Drag divider to various positions (20%, 80%), then double-click → always resets to 50%
- [ ] Single-click + drag still works normally after double-clicking