### PR TITLE
fix: wrap text blocks like prose instead of scrolling

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -326,6 +326,12 @@ body,
   margin-bottom: 1em;
 }
 
+/* Text blocks should wrap like prose, not scroll like code */
+.preview-pane pre:has(code.language-text) {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 .preview-pane pre code {
   font-family: var(--font-mono);
   font-size: 13px;


### PR DESCRIPTION
## Summary

- Add CSS rule targeting `pre:has(code.language-text)` to apply `white-space: pre-wrap` and `word-wrap: break-word`, so ```text blocks wrap instead of scrolling horizontally
- Other code blocks (```js, ```python, etc.) retain horizontal scroll behavior

## Test plan

- [ ] Verify ```text code blocks wrap within the preview pane
- [ ] Verify ```js/```python blocks still scroll horizontally
- [ ] Check both light and dark themes

Closes #34