### PR TITLE
feat: add search and replace dialog (Cmd+F)

### DIFF
--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import CodeMirror, { type Extension } from "@uiw/react-codemirror";
 import { markdown } from "@codemirror/lang-markdown";
 import { EditorView } from "@codemirror/view";
+import { search } from "@codemirror/search";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { tags } from "@lezer/highlight";
 
@@ -93,7 +94,13 @@ const darkHighlighting = HighlightStyle.define([
 
 function buildExtensions(isDark: boolean): Extension[] {
   const highlighting = isDark ? darkHighlighting : lightHighlighting;
-  return [markdown(), baseTheme, EditorView.lineWrapping, syntaxHighlighting(highlighting)];
+  return [
+    markdown(),
+    baseTheme,
+    EditorView.lineWrapping,
+    syntaxHighlighting(highlighting),
+    search({ top: true }),
+  ];
 }
 
 export default function EditorPane({ content, onChange, isDark }: EditorPaneProps) {
@@ -132,7 +139,7 @@ export default function EditorPane({ content, onChange, isDark }: EditorPaneProp
           rectangularSelection: false,
           defaultKeymap: true,
           syntaxHighlighting: false,
-          searchKeymap: false,
+          searchKeymap: true,
           lintKeymap: false,
         }}
         style={{ height: "100%" }}

--- a/src/theme.css
+++ b/src/theme.css
@@ -440,6 +440,91 @@ body,
   background: var(--text-muted);
 }
 
+/* ========== Search Panel ========== */
+.editor-pane .cm-editor .cm-panels {
+  background: var(--bg-toolbar);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.editor-pane .cm-editor .cm-search {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.editor-pane .cm-editor .cm-search label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.editor-pane .cm-editor .cm-search input[type="text"],
+.editor-pane .cm-editor .cm-search .cm-textfield {
+  background: var(--bg-editor);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  outline: none;
+}
+
+.editor-pane .cm-editor .cm-search input[type="text"]:focus,
+.editor-pane .cm-editor .cm-search .cm-textfield:focus {
+  border-color: var(--link-color);
+}
+
+.editor-pane .cm-editor .cm-search input[type="checkbox"] {
+  accent-color: var(--link-color);
+}
+
+.editor-pane .cm-editor .cm-search button,
+.editor-pane .cm-editor .cm-search .cm-button {
+  background: var(--copy-btn-bg);
+  color: var(--text-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.editor-pane .cm-editor .cm-search button:hover,
+.editor-pane .cm-editor .cm-search .cm-button:hover {
+  background: var(--copy-btn-hover);
+}
+
+.editor-pane .cm-editor .cm-search button[name="close"] {
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 16px;
+  padding: 2px 6px;
+}
+
+.editor-pane .cm-editor .cm-search button[name="close"]:hover {
+  color: var(--text-primary);
+  background: var(--copy-btn-bg);
+}
+
+.editor-pane .cm-editor .cm-searchMatch {
+  background: rgba(212, 165, 116, 0.35);
+  border-radius: 2px;
+}
+
+.editor-pane .cm-editor .cm-searchMatch-selected {
+  background: rgba(74, 124, 150, 0.4);
+}
+
 /* ========== Loading Overlay ========== */
 .loading-overlay {
   position: fixed;

--- a/src/theme.css
+++ b/src/theme.css
@@ -522,7 +522,9 @@ body,
 }
 
 .editor-pane .cm-editor .cm-searchMatch-selected {
-  background: rgba(74, 124, 150, 0.4);
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 2px;
 }
 
 /* ========== Loading Overlay ========== */


### PR DESCRIPTION
## Summary

- Enable CodeMirror's built-in search/replace panel via `@codemirror/search` extension with `search({ top: true })`
- Set `searchKeymap: true` in basicSetup to activate Cmd+F, Cmd+G keybindings
- Add themed CSS for the search panel matching both light and dark modes

Closes #35